### PR TITLE
Support for creating X509 CSRs

### DIFF
--- a/include/cc7/crypto/X509.h
+++ b/include/cc7/crypto/X509.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Wultra s.r.o.
+ * Copyright 2026 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,19 @@
 
 #pragma once
 
-#include <cc7/crypto/Cipher.h>
-#include <cc7/crypto/MAC.h>
-#include <cc7/crypto/MessageDigest.h>
-#include <cc7/crypto/Signature.h>
-#include <cc7/crypto/KeyAgreement.h>
-#include <cc7/crypto/KeyDerivation.h>
-#include <cc7/crypto/KeyEncapsulation.h>
-#include <cc7/crypto/AEAD.h>
-#include <cc7/crypto/Random.h>
-#include <cc7/crypto/NonceGenerator.h>
-#include <cc7/crypto/X509.h>
+#include <cc7/crypto/KeyPair.h>
+
+namespace cc7::crypto {
+
+/// The `X509` class contains various utility functions for X509 standard.
+class X509
+{
+public:
+
+    static std::string createCSR(const PrivateKey& privateKey,
+                                 const std::map<std::string, std::string>& dn_items,
+                                 const std::vector<std::string>& san_items);
+    
+};
+
+} // namespace cc7::crypto

--- a/proj-xcode/cc7.xcodeproj/project.pbxproj
+++ b/proj-xcode/cc7.xcodeproj/project.pbxproj
@@ -84,6 +84,12 @@
 		BF0059502D9E982900C0F3AF /* ECKeyPair.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF00594F2D9E982900C0F3AF /* ECKeyPair.cpp */; };
 		BF0059512D9E982900C0F3AF /* ECKeyPair.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF00594F2D9E982900C0F3AF /* ECKeyPair.cpp */; };
 		BF0059522D9E982900C0F3AF /* ECKeyPair.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF00594F2D9E982900C0F3AF /* ECKeyPair.cpp */; };
+		BF06AC302F44A465008C83B0 /* X509.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF06AC2F2F44A465008C83B0 /* X509.cpp */; };
+		BF06AC312F44A465008C83B0 /* X509.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF06AC2F2F44A465008C83B0 /* X509.cpp */; };
+		BF06AC322F44A465008C83B0 /* X509.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF06AC2F2F44A465008C83B0 /* X509.cpp */; };
+		BF06AC392F45E029008C83B0 /* X509Tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF06AC382F45E029008C83B0 /* X509Tests.cpp */; };
+		BF06AC3A2F45E029008C83B0 /* X509Tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF06AC382F45E029008C83B0 /* X509Tests.cpp */; };
+		BF06AC3B2F45E029008C83B0 /* X509Tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF06AC382F45E029008C83B0 /* X509Tests.cpp */; };
 		BF0825D92E0167B400B89A68 /* JsonValueTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF0825D82E0167B400B89A68 /* JsonValueTests.cpp */; };
 		BF0825DA2E0167B400B89A68 /* JsonValueTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF0825D82E0167B400B89A68 /* JsonValueTests.cpp */; };
 		BF0825DB2E0167B400B89A68 /* JsonValueTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF0825D82E0167B400B89A68 /* JsonValueTests.cpp */; };
@@ -495,6 +501,9 @@
 		BF00594F2D9E982900C0F3AF /* ECKeyPair.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ECKeyPair.cpp; sourceTree = "<group>"; };
 		BF0059582DA024AD00C0F3AF /* SymmetricKey.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SymmetricKey.cpp; sourceTree = "<group>"; };
 		BF0059592DA025CD00C0F3AF /* SymmetricKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SymmetricKey.h; sourceTree = "<group>"; };
+		BF06AC2C2F44A006008C83B0 /* X509.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = X509.h; sourceTree = "<group>"; };
+		BF06AC2F2F44A465008C83B0 /* X509.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = X509.cpp; sourceTree = "<group>"; };
+		BF06AC382F45E029008C83B0 /* X509Tests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = X509Tests.cpp; sourceTree = "<group>"; };
 		BF0825D82E0167B400B89A68 /* JsonValueTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JsonValueTests.cpp; sourceTree = "<group>"; };
 		BF0D67EF1CE63DF90070D853 /* PrefixCC7.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrefixCC7.pch; sourceTree = "<group>"; };
 		BF0D67F01CE63EDA0070D853 /* PrefixCC7Tests.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrefixCC7Tests.pch; sourceTree = "<group>"; };
@@ -762,6 +771,7 @@
 				BF5A00152DA5D0DA0068992F /* KeyEncapsulation.h */,
 				BF5A00242DA675B50068992F /* KeyDerivation.h */,
 				BF0058DB2D996AA400C0F3AF /* AEAD.h */,
+				BF06AC2C2F44A006008C83B0 /* X509.h */,
 			);
 			path = crypto;
 			sourceTree = "<group>";
@@ -788,6 +798,7 @@
 				BF5A00252DA6768E0068992F /* KeyDerivation.cpp */,
 				BF0058DE2D9A9F9B00C0F3AF /* AEAD.cpp */,
 				BF00593D2D9E7E0300C0F3AF /* Parameter.cpp */,
+				BF06AC2F2F44A465008C83B0 /* X509.cpp */,
 			);
 			path = crypto;
 			sourceTree = "<group>";
@@ -911,6 +922,7 @@
 				BF14D45A2DD324CD00BA7F51 /* AEADTests.cpp */,
 				BF5A003C2DAE486D0068992F /* ImportKeyTests.cpp */,
 				BF14D46C2DD48CB400BA7F51 /* NonceGeneratorTests.cpp */,
+				BF06AC382F45E029008C83B0 /* X509Tests.cpp */,
 			);
 			path = cc7crypto;
 			sourceTree = "<group>";
@@ -1658,6 +1670,7 @@
 				BF5A000A2DA53F570068992F /* SignatureTests.cpp in Sources */,
 				BFB494011CE8E79400F8D81B /* TestDirectory.cpp in Sources */,
 				BF00592C2D9C49C400C0F3AF /* g_testFiles.cpp in Sources */,
+				BF06AC3B2F45E029008C83B0 /* X509Tests.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1700,6 +1713,7 @@
 				BF4D858D2DE727B900D32F55 /* JwtException.cpp in Sources */,
 				BF8B2B192DC7EE5B00989AF3 /* PBKDF2.cpp in Sources */,
 				BF00591F2D9BFB8A00C0F3AF /* HMAC.cpp in Sources */,
+				BF06AC322F44A465008C83B0 /* X509.cpp in Sources */,
 				BF4D85672DE5A47B00D32F55 /* JsonValue.cpp in Sources */,
 				BF8EEC0326662A01009AC5FD /* PlatformApple.mm in Sources */,
 				BFF21B842E13E858000BF450 /* ObjcJson.mm in Sources */,
@@ -1786,6 +1800,7 @@
 				BF5A00092DA53F570068992F /* SignatureTests.cpp in Sources */,
 				BF8EEC2726662A0B009AC5FD /* TestDirectory.cpp in Sources */,
 				BF00592B2D9C49C400C0F3AF /* g_testFiles.cpp in Sources */,
+				BF06AC3A2F45E029008C83B0 /* X509Tests.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1810,6 +1825,7 @@
 				BF4D858E2DE727B900D32F55 /* JwtException.cpp in Sources */,
 				BF8B2B1A2DC7EE5B00989AF3 /* PBKDF2.cpp in Sources */,
 				BF00591E2D9BFB8A00C0F3AF /* HMAC.cpp in Sources */,
+				BF06AC302F44A465008C83B0 /* X509.cpp in Sources */,
 				BF4D85682DE5A47B00D32F55 /* JsonValue.cpp in Sources */,
 				BFE174041CC9664500039466 /* PlatformApple.mm in Sources */,
 				BFF21B862E13E858000BF450 /* ObjcJson.mm in Sources */,
@@ -1878,6 +1894,7 @@
 				BF4D858F2DE727B900D32F55 /* JwtException.cpp in Sources */,
 				BF8B2B182DC7EE5B00989AF3 /* PBKDF2.cpp in Sources */,
 				BF0059202D9BFB8A00C0F3AF /* HMAC.cpp in Sources */,
+				BF06AC312F44A465008C83B0 /* X509.cpp in Sources */,
 				BF4D85692DE5A47B00D32F55 /* JsonValue.cpp in Sources */,
 				BFFE8AA32449B4F80032821F /* PlatformApple.mm in Sources */,
 				BFF21B852E13E858000BF450 /* ObjcJson.mm in Sources */,
@@ -1964,6 +1981,7 @@
 				BF5A000B2DA53F570068992F /* SignatureTests.cpp in Sources */,
 				BFFE8AC72449B53C0032821F /* TestDirectory.cpp in Sources */,
 				BF00592D2D9C49C400C0F3AF /* g_testFiles.cpp in Sources */,
+				BF06AC392F45E029008C83B0 /* X509Tests.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/Android.mk
+++ b/src/Android.mk
@@ -83,7 +83,8 @@ LOCAL_SRC_FILES += \
 	cc7/crypto/KeyDerivation.cpp \
 	cc7/crypto/AEAD.cpp \
 	cc7/crypto/Parameter.cpp \
-	cc7/crypto/NonceGenerator.cpp
+	cc7/crypto/NonceGenerator.cpp \
+	cc7/crypto/X509.cpp
 
 # cc7/crypto/alg
 LOCAL_SRC_FILES += \
@@ -208,7 +209,8 @@ LOCAL_SRC_FILES += \
 	cc7tests/tests/cc7crypto/MACTests.cpp \
 	cc7tests/tests/cc7crypto/MessageDigestTests.cpp \
 	cc7tests/tests/cc7crypto/SignatureTests.cpp \
-	cc7tests/tests/cc7crypto/NonceGeneratorTests.cpp
+	cc7tests/tests/cc7crypto/NonceGeneratorTests.cpp \
+	cc7tests/tests/cc7crypto/X509Tests.cpp
 
 # Unit tests (OpenSSL)
 LOCAL_SRC_FILES += \

--- a/src/cc7/crypto/CryptoPrivate.cpp
+++ b/src/cc7/crypto/CryptoPrivate.cpp
@@ -15,6 +15,9 @@
  */
 
 #include "CryptoPrivate.h"
+#include "alg/ECKeyPair.h"
+#include "alg/MLDSA.h"
+
 #include <openssl/provider.h>
 
 namespace cc7::crypto {
@@ -59,6 +62,26 @@ bool stringHasSuffix(const std::string & str, const std::string & suffix)
 {
     return str.size() >= suffix.size() &&
            str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+std::string stringJoin(const std::vector<std::string>& items, const std::string& separator)
+{
+    std::string result;
+    if (!items.empty()) {
+        // calculate result size to prevent re-allocation
+        size_t total_size = separator.size() * (items.size() - 1);
+        for (const auto& s : items) {
+            total_size += s.size();
+        }
+        result.reserve(total_size);
+        // concatenate
+        result = items[0];
+        for (size_t i = 1; i < items.size(); ++i) {
+            result += separator;
+            result += items[i];
+        }
+    }
+    return result;
 }
 
 #define NULLCTX 1
@@ -116,6 +139,48 @@ OSSL_LIB_CTX * ossl_ctx()
     }
     throw CryptoException("OSSL_LIB_CTX is not initialized yet");
 #endif
+}
+
+// MARK: Getting EVP_KEY from high level keys
+
+EVPKeyPair getLLKey(const PublicKey& public_key)
+{
+    auto& key_type = public_key.getKeyType();
+    if (stringHasPrefix(key_type, "P-")) {
+        try {
+            return checkECPublicKey(public_key, nullptr).getEvpKey();
+        } catch (...) {
+            // ignore, try another key type
+        }
+    }
+    if (stringHasPrefix(key_type, "ML-DSA-")) {
+        try {
+            return checkMLDSAPublicKey(public_key, nullptr).getEvpKey();
+        } catch (...) {
+            // ignore
+        }
+    }
+    throw std::invalid_argument("Cannot get low level key: " + key_type);
+}
+
+EVPKeyPair getLLKey(const PrivateKey& private_key, bool check_signing)
+{
+    auto& key_type = private_key.getKeyType();
+    if (stringHasPrefix(key_type, "P-")) {
+        try {
+            return checkECPrivateKey(private_key, nullptr, check_signing).getEvpKey();
+        } catch (...) {
+            // ignore, try another key type
+        }
+    }
+    if (stringHasPrefix(key_type, "ML-DSA-")) {
+        try {
+            return checkMLDSAPrivateKey(private_key, nullptr).getEvpKey();
+        } catch (...) {
+            // ignore
+        }
+    }
+    throw std::invalid_argument("Cannot get low level key: " + key_type);
 }
 
 } // namespace cc7::crypto

--- a/src/cc7/crypto/CryptoPrivate.h
+++ b/src/cc7/crypto/CryptoPrivate.h
@@ -19,6 +19,7 @@
 #include "detail/OSSLObjects.h"
 #include <cc7/crypto/CryptoConstants.h>
 #include <cc7/crypto/CryptoException.h>
+#include <cc7/crypto/KeyPair.h>
 
 namespace cc7::crypto {
 
@@ -34,7 +35,20 @@ void throwSealedKey [[noreturn]] (const std::string & key_type);
 
 bool stringHasPrefix(const std::string & str, const std::string & prefix);
 bool stringHasSuffix(const std::string & str, const std::string & suffix);
+std::string stringJoin(const std::vector<std::string>& items, const std::string& separator);
 
 OSSL_LIB_CTX * ossl_ctx();
+
+/// Extract low-level key from given public key object. If such key is not supported,
+/// then throws `std::invalid_argument` exception.
+/// - Parameter public_key: Public key object.
+EVPKeyPair getLLKey(const PublicKey& public_key);
+
+/// Extract low-level key from given private key object. If such key is not supported,
+/// then throws `std::invalid_argument` exception.
+/// - Parameters:
+///   - private_key: Private key object.
+///   - check_signing: If true, then also check capability to sign data with the key.
+EVPKeyPair getLLKey(const PrivateKey& private_key, bool check_signing);
 
 } // namespace cc7::crypto

--- a/src/cc7/crypto/X509.cpp
+++ b/src/cc7/crypto/X509.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cc7/crypto/X509.h>
+#include "CryptoPrivate.h"
+#include "alg/ECKeyPair.h"
+
+namespace cc7::crypto {
+
+// MARK: - CSR
+
+static void addSANExtensions(const X509Req& req, const std::vector<std::string>& san_items)
+{
+    if (san_items.empty()) {
+        return;
+    }
+    
+    std::string san_list = stringJoin(san_items, ",");
+    
+    X509V3_CTX ctx;
+    X509V3_set_ctx_nodb(&ctx);
+    X509V3_set_ctx(&ctx, nullptr, nullptr, req, nullptr, 0);
+
+    // Build extension object
+    auto ext = X509Extension::take(X509V3_EXT_conf_nid(nullptr, &ctx, NID_subject_alt_name, san_list.c_str()));
+    if (!ext) {
+        throw CryptoException("Failed to create X509 SAN extension");
+    }
+    // Build stack
+    auto ext_stack = X509ExtensionStack::empty();
+    if (!ext_stack) {
+        throw CryptoException("Failed to create X509 SAN extension stack");
+    }
+    // push extension to stack.
+    if (sk_X509_EXTENSION_push(ext_stack, ext) == 0) {
+        throw CryptoException("Failed to push SAN extension into stack");
+    }
+    // The extension is added to stack, so X509Extension should no longer manage the instance.
+    // Otherwise double memory release would occur.
+    ext.release();
+    
+    // Finally, add extension stack into CSR request
+    if (X509_REQ_add_extensions(req, ext_stack) != 1) {
+        throw CryptoException("Failed to add SAN extension into CSR");
+    }
+}
+
+static void addDNItems(const X509Name& name, const std::map<std::string, std::string> &dn_items)
+{
+    for (const auto& [key, value] : dn_items) {
+        if (key.empty()) {
+            throw std::invalid_argument("DN item should not have empty key");
+        }
+        if (value.empty()) {
+            // Skip empty value
+            continue;
+        }
+        if (1 != X509_NAME_add_entry_by_txt(name, key.c_str(), MBSTRING_UTF8,
+                                            reinterpret_cast<const unsigned char*>(value.c_str()),
+                                            static_cast<int>(value.size()),
+                                            -1, 0)) {
+            throw CryptoException("Adding DN name failed for field: " + key);
+        }
+    }
+}
+
+static void signCSR(const EVPKeyPair& pkey, const std::string& pkey_alg, const X509Req& req)
+{
+    auto mctx = EVPMDContext::empty();
+    const EVP_MD * digest;
+    bool failure = false;
+    if (stringHasPrefix(pkey_alg, "P-")) {
+        if (pkey_alg == ECCurveSpec::P_256.name) {
+            digest = EVP_sha256();
+        } else if (pkey_alg == ECCurveSpec::P_384.name) {
+            digest = EVP_sha384();
+        } else if (pkey_alg == ECCurveSpec::P_521.name) {
+            digest = EVP_sha512();
+        } else {
+            failure = true;
+        }
+    } else if (stringHasPrefix(pkey_alg, "ML-DSA-")) {
+        // For algorithms like ML-DSA, there isn't a traditional external digest.
+        digest = nullptr;
+    } else {
+        failure = true;
+    }
+    
+    if (failure) {
+        throw CryptoException("Cannot determine digest for key type: " + pkey_alg);
+    }
+    // Set key to request
+    if (X509_REQ_set_pubkey(req, pkey) != 1) {
+        throw CryptoException("Failed to set private key to CSR");
+    }
+    // Do sign
+    if (X509_REQ_sign(req, pkey, digest) <= 0) {
+        throw CryptoException("Failed to sign CSR");
+    }
+}
+
+std::string X509::createCSR(const PrivateKey& private_key, const std::map<std::string, std::string> &dn_items, const std::vector<std::string> &san_items)
+{
+    auto pkey = getLLKey(private_key, true);
+    
+    auto req = X509Req::empty();
+    if (!req) {
+        throw CryptoException("Failed to create X509_REQ object");
+    }
+    auto name = X509Name::empty();
+    if (!name) {
+        throw CryptoException("Failed to create X509_NAME object");
+    }
+    // Add DN items
+    addDNItems(name, dn_items);
+    
+    // Add SAN extension
+    addSANExtensions(req, san_items);
+ 
+    if (X509_REQ_set_subject_name(req, name) != 1) {
+        throw CryptoException("Failed to set subject name to CSR");
+    }
+    
+    // Do sign
+    signCSR(pkey, private_key.getKeyType(), req);
+    
+    // So far so good, prepare "memory" BIO object
+    auto bio = OSSLBIO::take(BIO_new(BIO_s_mem()));
+    if (!bio) {
+        throw CryptoException("Failed to allocate memory buffer for CSR output");
+    }
+    
+    if (PEM_write_bio_X509_REQ(bio, req) != 1) {
+        throw CryptoException("Failed to write CSR into PEM format");
+    }
+    // Extract data from BIO
+    BUF_MEM* bptr = nullptr;
+    BIO_get_mem_ptr(bio, &bptr);
+    if (!bptr) {
+        throw CryptoException("BIO_get_mem_ptr failed");
+    }
+    
+    // Finally return string with CSR in PEM format
+    return std::string(bptr->data, bptr->length);
+}
+
+} // namespace cc7::crypto

--- a/src/cc7/crypto/detail/LLObject.h
+++ b/src/cc7/crypto/detail/LLObject.h
@@ -26,16 +26,18 @@ namespace cc7::crypto {
  such as `EVP_PKEY` structure.
  
  The template class implements casting operator to `T*` and therefore can be easily used as
- a parameter to functions, which requires pointet to type T.
+ a parameter to functions, which requires pointer to type T.
+ 
+ The CreateFunc, RetainFunc and ReleaseFunc should not throw an exception in case of failure.
  */
 template <typename T, T* (*CreateFunc)(), int (*RetainFunc)(T*), void (*ReleaseFunc)(T*)> class TLLRefObject {
 public:
     
     /// Plain constructor creates an invalid object.
-    TLLRefObject() : _ll_object(nullptr) {}
+    TLLRefObject() noexcept : _ll_object(nullptr) {}
     
     // Copy constructor - retains ll object
-    TLLRefObject(const TLLRefObject & other) {
+    TLLRefObject(const TLLRefObject & other) noexcept {
         _ll_object = other._ll_object;
         if (_ll_object) {
             RetainFunc(_ll_object);
@@ -43,7 +45,7 @@ public:
     }
     
     // Move constructor - move ptr only.
-    TLLRefObject(TLLRefObject && other) {
+    TLLRefObject(TLLRefObject && other) noexcept {
         _ll_object = other._ll_object;
         other._ll_object = nullptr;
     }
@@ -54,7 +56,7 @@ public:
     }
     
     // Copy Assignment
-    TLLRefObject& operator=(const TLLRefObject& other) {
+    TLLRefObject& operator=(const TLLRefObject& other) noexcept {
         if (this != &other) {
             assign(other._ll_object);
         }
@@ -62,7 +64,7 @@ public:
     }
     
     // Move Assignment
-    TLLRefObject& operator=(TLLRefObject&& other) {
+    TLLRefObject& operator=(TLLRefObject&& other) noexcept {
         if (this != &other) {
             if (_ll_object != other._ll_object) {
                 destroy();
@@ -74,45 +76,50 @@ public:
     }
     
     // Take ownership of provided object. The reference count is not increased.
-    static TLLRefObject take(T * ll_object) {
+    static TLLRefObject take(T * ll_object) noexcept {
         return TLLRefObject(ll_object, false);
     }
 
     // Keep provided object and increase the reference count.
-    static TLLRefObject ref(T * ll_object) {
+    static TLLRefObject ref(T * ll_object) noexcept {
         return TLLRefObject(ll_object, true);
     }
             
     // Create an empty object. If CreateFunc template parameter is not provided, then
     // it's equal to ::invalid().
-    static TLLRefObject empty() {
+    static TLLRefObject empty() noexcept {
         return TLLRefObject(CreateFunc ? CreateFunc() : nullptr, false);
     }
     
     // Return low level object captured in this object.
-    T* object() const {
+    T* object() const noexcept {
         return _ll_object;
     }
 
     // Return reference to internal low level object pointer. If object contains valid low level object,
     // then this object is destroyed.
-    T** objectRef() {
+    T** objectRef() noexcept {
         destroy();
         return &_ll_object;
     }
     
-    // Cast TLLObject to T pointer to use in low-level functions automatically.
-    operator T * () const {
+    // Cast TLLRefObject to T pointer to use in low-level functions automatically.
+    operator T * () const noexcept {
         return _ll_object;
     }
     
+    /// Cast TLLRefObject to bool to test nullability.
+    explicit operator bool() const noexcept {
+        return isValid();
+    }
+    
     // Return true if object contains valid low-level object.
-    bool isValid() const {
+    bool isValid() const noexcept {
         return _ll_object != nullptr;
     }
     
     // Assign low level object
-    void assign(T * ll_object) {
+    void assign(T * ll_object) noexcept {
         if (_ll_object != ll_object) {
             destroy();
             _ll_object = ll_object;
@@ -123,7 +130,7 @@ public:
     }
     
     // Destroy low level object.
-    void destroy() {
+    void destroy() noexcept {
         if (_ll_object) {
             ReleaseFunc(_ll_object);
             _ll_object = nullptr;
@@ -132,7 +139,7 @@ public:
             
 protected:
     
-    TLLRefObject(T * ll_object, bool retain) : _ll_object(ll_object) {
+    TLLRefObject(T * ll_object, bool retain) noexcept : _ll_object(ll_object) {
         if (_ll_object && retain) {
             RetainFunc(_ll_object);
         }
@@ -149,22 +156,24 @@ private:
  objects, such as BIGNUM.
  
  The template class implements casting operator to `T*` and therefore can be easily used as
- a parameter to functions, which requires pointet to type T.
+ a parameter to functions, which requires pointer to type T.
+ 
+ Both CreateFunc and ReleaseFunc should not throw an exception.
  */
 template <typename T, T* (*CreateFunc)(), void (*ReleaseFunc)(T*)> class TLLObject {
 public:
     
     // Plain constructor creates an invalid object.
-    TLLObject() : _ll_object(nullptr) {}
+    TLLObject() noexcept : _ll_object(nullptr) {}
     
     // Move constructor - move ptr only.
-    TLLObject(TLLObject && other) {
+    TLLObject(TLLObject && other) noexcept {
         _ll_object = other._ll_object;
         other._ll_object = nullptr;
     }
     
     // Move Assignment
-    TLLObject& operator=(TLLObject&& other) {
+    TLLObject& operator=(TLLObject&& other) noexcept {
         if (this != &other) {
             if (_ll_object != other._ll_object) {
                 destroy();
@@ -177,13 +186,13 @@ public:
 
     // Take ownership of provided object. The low level object will be destroyed in object's
     // constructor.
-    static TLLObject take(T * ll_object) {
+    static TLLObject take(T * ll_object) noexcept {
         return TLLObject(ll_object);
     }
             
     // Create an empty object. If CreateFunc template parameter is not provided, then
     // the created object is invalid.
-    static TLLObject empty() {
+    static TLLObject empty() noexcept {
         return TLLObject(CreateFunc ? CreateFunc() : nullptr);
     }
         
@@ -193,121 +202,61 @@ public:
     }
     
     // Return low level object captured in this object.
-    T * object() const {
+    T * object() const noexcept {
         return _ll_object;
     }
     
     // Return reference to internal low level object pointer. If object contains valid low level object,
     // then this object is destroyed.
-    T** objectRef() {
+    T** objectRef() noexcept {
         destroy();
         return &_ll_object;
     }
 
     
     // Cast TLLObject to T pointer to use in low-level functions automatically.
-    operator T * () const {
+    operator T * () const noexcept {
         return _ll_object;
     }
     
+    // Cast TLLObject to bool to test nullability.
+    explicit operator bool() const noexcept {
+        return isValid();
+    }
+    
     // Return true if object contains valid low-level object.
-    bool isValid() const {
+    bool isValid() const noexcept {
         return _ll_object != nullptr;
     }
         
-    void destroy() {
+    void destroy() noexcept {
         if (_ll_object) {
             ReleaseFunc(_ll_object);
             _ll_object = nullptr;
         }
     }
     
-    void assign(T * ll_object) {
+    void assign(T * ll_object) noexcept {
         if (_ll_object != ll_object) {
             destroy();
         }
         _ll_object = ll_object;
     }
     
+    // Take away referenced low-level object.
+    T* release() noexcept {
+        auto ret = _ll_object;
+        _ll_object = nullptr;
+        return ret;
+    }
+    
 protected:
     
-    TLLObject(T * ll_object) : _ll_object(ll_object) {
-    }
+    TLLObject(T * ll_object) noexcept : _ll_object(ll_object) {}
 
 private:
     
     T * _ll_object;
-};
-
-/**
- The `TLLMemory` template allows to capture memory allocated elsewhere and guarantess that
- it's released with the predefined function.
- */
-template <typename T, void (*ReleaseFunc)(T*)> class TLLMemory {
-public:
-    TLLMemory() : _ptr(nullptr) {}
-    
-    ~TLLMemory() {
-        destroy();
-    }
-    
-    // Move constructor - move ptr only.
-    TLLMemory(TLLMemory && other) {
-        _ptr = other._ptr;
-        other._ptr = nullptr;
-    }
-    
-    // Move Assignment
-    TLLMemory& operator=(TLLMemory&& other) {
-        if (this != &other) {
-            if (_ptr != other._ptr) {
-                destroy();
-            }
-            _ptr = other._ptr;
-            other._ptr = nullptr;
-        }
-        return *this;
-    }
-
-    // Take ownership of provided pointer.
-    static TLLMemory take(T * ptr) {
-        return TLLMemory(ptr);
-    }
-    
-    void destroy() {
-        if (_ptr) {
-            ReleaseFunc(_ptr);
-            _ptr = nullptr;
-        }
-    }
-    
-    // Return pointer captured in this object.
-    T * ptr() const {
-        return _ptr;
-    }
-    
-    // Return reference to pointer captured in this object. If pointer is already allocated, then
-    // captured memory is destroyed.
-    T ** ref() {
-        destroy();
-        return &_ptr;
-    }
-    
-    // Cast TLLMemory to T pointer to use in low-level functions automatically.
-    operator T * () const {
-        return _ptr;
-    }
-    
-    // Return true if object contains valid pointer.
-    bool isValid() const {
-        return _ptr != nullptr;
-    }
-    
-private:
-    
-    TLLMemory(T * ptr) : _ptr(ptr) {}
-    
-    T * _ptr;
 };
 
 /**

--- a/src/cc7/crypto/detail/OSSLObjects.h
+++ b/src/cc7/crypto/detail/OSSLObjects.h
@@ -33,6 +33,9 @@
 #include <openssl/bio.h>
 #include <openssl/buffer.h>
 #include <openssl/hpke.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/pem.h>
 
 namespace cc7::crypto {
 
@@ -99,6 +102,25 @@ typedef TLLObject<OSSL_ENCODER_CTX, nullptr, OSSL_ENCODER_CTX_free> OSSLEncoderC
 /// The `OSSLCtx` is wrapper for `OSSL_LIB_CTX`.
 typedef TLLObject<OSSL_LIB_CTX, OSSL_LIB_CTX_new, OSSL_LIB_CTX_free> OSSLCtx;
 
+// X509
+
+/// The `X509Req` is wrapper for `X509_REQ`.
+typedef TLLObject<X509_REQ, X509_REQ_new, X509_REQ_free> X509Req;
+
+/// The `X509Name` is wrapper for `X509_NAME`.
+typedef TLLObject<X509_NAME, X509_NAME_new, X509_NAME_free> X509Name;
+
+/// The `X509Extension` is wrapper for `X509_EXTENSION`.
+typedef TLLObject<X509_EXTENSION, nullptr, X509_EXTENSION_free> X509Extension;
+
+inline X509_EXTENSIONS* X509ExtensionStack_New() {
+    return sk_X509_EXTENSION_new_null();
+}
+inline void X509ExtensionStack_Free(X509_EXTENSIONS* s) {
+    sk_X509_EXTENSION_pop_free(s, X509_EXTENSION_free);
+}
+/// The `X509ExtensionStack` is wrapper for `STACK_OF(X509_EXTENSION)` (e.g. `X509_EXTENSIONS`).
+typedef TLLObject<X509_EXTENSIONS, X509ExtensionStack_New, X509ExtensionStack_Free> X509ExtensionStack;
 
 // Other
 

--- a/src/cc7tests/tests/EmbeddedTestsList.cpp
+++ b/src/cc7tests/tests/EmbeddedTestsList.cpp
@@ -52,6 +52,7 @@ namespace tests
         CC7_ADD_UNIT_TEST(CipherTests, list);
         CC7_ADD_UNIT_TEST(AEADTests, list);
         CC7_ADD_UNIT_TEST(NonceGeneratorTests, list);
+        CC7_ADD_UNIT_TEST(X509Tests, list);
         
         // cc7/json-jwt frameworks tests
         CC7_ADD_UNIT_TEST(JsonReaderTests, list);

--- a/src/cc7tests/tests/cc7crypto/X509Tests.cpp
+++ b/src/cc7tests/tests/cc7crypto/X509Tests.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cc7tests/CC7Tests.h>
+#include <cc7/crypto/Crypto.h>
+
+namespace cc7::tests {
+
+class X509Tests : public UnitTest
+{
+public:
+    X509Tests()
+    {
+        CC7_REGISTER_TEST_METHOD(testCreateCSR);
+        CC7_REGISTER_TEST_METHOD(testWrongKeyTypesForCSR);
+    }
+    
+    const bool dumpCSR = false;
+    
+    void testCreateCSR()
+    {
+        const auto algs = std::vector<std::string> {
+            "ML-DSA-44", "ML-DSA-65", "ML-DSA-87",
+            "P-256", "P-384", "P-521",
+        };
+        auto dn = std::map<std::string, std::string> {
+            { "C", "CZ" },
+            { "O", "Example" },
+            { "CN", "example.com" }
+        };
+        auto san = std::vector<std::string> {
+            "DNS:example.com",
+            "DNS:www.example.com"
+        };
+        for (auto alg : algs) {
+            ccstMessage("%s", alg.c_str());
+            auto keyPair = cc7::crypto::KeyPair::generateKeyPair(alg);
+            // re-export key
+            auto privateKey = std::dynamic_pointer_cast<cc7::crypto::PrivateKey>(keyPair->getPrivateKey().duplicate());
+            ccstAssertNotNull(privateKey);
+            
+            auto csr = cc7::crypto::X509::createCSR(*privateKey, dn, {});
+            ccstAssertFalse(csr.empty());
+            if (dumpCSR) ccstMessage("CSR (no ext):\n%s", csr.c_str());
+            csr = cc7::crypto::X509::createCSR(*privateKey, dn, san);
+            ccstAssertFalse(csr.empty());
+            if (dumpCSR) ccstMessage("CSR (with ext):\n%s", csr.c_str());
+        }
+    }
+    
+    void testWrongKeyTypesForCSR()
+    {
+        const auto algs = std::vector<std::string> {
+            "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024",
+            "DHKEM-P256-HKDF-SHA256", "DHKEM-P384-HKDF-SHA384", "DHKEM-P521-HKDF-SHA512"
+        };
+        auto dn = std::map<std::string, std::string> {
+            { "C", "CZ" },
+            { "O", "Example" },
+            { "CN", "example.com" }
+        };
+        for (auto alg : algs) {
+            auto keyPair = cc7::crypto::KeyPair::generateKeyPair(alg);
+            ccstMustThrow(std::exception, cc7::crypto::X509::createCSR(keyPair->getPrivateKey(), dn, {}));
+        }
+    }
+};
+
+CC7_CREATE_UNIT_TEST(X509Tests, "cc7")
+    
+} // cc7
+


### PR DESCRIPTION
Other changes:
- All methods in `TLLRefObject` and `TLLObject` are now annotated with `noexcept`
- Added `release()` method to `TLLObject` that allows to take away managed object