### PR TITLE
Added support for watchOS on arm64 architecture

### DIFF
--- a/openssl-build/build-apple.sh
+++ b/openssl-build/build-apple.sh
@@ -616,8 +616,11 @@ function BUILD_APPLE_PLATFORM_SWITCH
             *_watchos-cross-armv7k.h)
                 IF_CONDITION="TARGET_OS_WATCH && TARGET_OS_EMBEDDED && TARGET_CPU_ARM"
                 ;;
+            *_watchos-cross-arm64.h)
+                IF_CONDITION="TARGET_OS_WATCH && TARGET_OS_EMBEDDED && TARGET_CPU_ARM64 && defined(__LP64__)"
+                ;;
             *_watchos-cross-arm64_32.h)
-                IF_CONDITION="TARGET_OS_WATCH && TARGET_OS_EMBEDDED && TARGET_CPU_ARM64"
+                IF_CONDITION="TARGET_OS_WATCH && TARGET_OS_EMBEDDED && TARGET_CPU_ARM64 && defined(__ILP32__)"
                 ;;
             *_watchos-sim-cross-arm64.h)
                 IF_CONDITION="TARGET_OS_WATCH && TARGET_OS_SIMULATOR && TARGET_CPU_ARM64"

--- a/openssl-build/config-build.sh
+++ b/openssl-build/config-build.sh
@@ -28,7 +28,7 @@ APPLE_TARGETS+=" mac-catalyst-x86_64 mac-catalyst-arm64"
 APPLE_TARGETS+=" tvos-sim-cross-x86_64 tvos-sim-cross-arm64"
 APPLE_TARGETS+=" tvos64-cross-arm64"
 APPLE_TARGETS+=" watchos-sim-cross-arm64 watchos-sim-cross-x86_64"
-APPLE_TARGETS+=" watchos-cross-arm64_32 watchos-cross-armv7k"
+APPLE_TARGETS+=" watchos-cross-arm64 watchos-cross-arm64_32 watchos-cross-armv7k"
 # APPLE_TARGETS+=" macos64-x86_64 macos64-arm64"
 
 # Minimum system versions

--- a/openssl-build/config/20-apple-platforms.conf
+++ b/openssl-build/config/20-apple-platforms.conf
@@ -126,6 +126,12 @@ my %targets = ();
         perlasm_scheme   => "ios64",
     },
 
+    # watchOS Series 2026+
+    "watchos-cross-arm64" => {
+        inherit_from     => [ "darwin64-arm64", "watchos-base" ],
+    },
+
+
     # watchOS Simulator (arm64)
     "watchos-sim-cross-arm64" => {
         inherit_from     => [ "darwin64-arm64", "watchos-base" ],


### PR DESCRIPTION
This PR adds support for watchOS on arm64 architecture. This is a new requirement introduced in [April 2026](https://developer.apple.com/news/?id=zt8rydnt).