### PR TITLE
Fix #50: JsonValue now use std::variant

### DIFF
--- a/include/cc7/json/JsonValue.h
+++ b/include/cc7/json/JsonValue.h
@@ -18,9 +18,9 @@
 
 #include <cc7/ByteArray.h>
 #include <cc7/Base64.h>
-#include <cc7/detail/StringUtils.h>
 #include <map>
 #include <vector>
+#include <variant>
 
 namespace cc7::json {
 
@@ -40,93 +40,43 @@ public:
         Double,
         Boolean,
     };
-    
+        
     typedef std::map<std::string, JsonValue> TObject;
     typedef std::vector<JsonValue> TArray;
     typedef std::string TString;
+        
+    JsonValue()                             : _v(TNaT::Value) {}
+    JsonValue(Type t);
+    ~JsonValue();
     
-    JsonValue()                     : _t(NaT), _copy_ptr(nullptr) {}
+    JsonValue(const JsonValue&) = default;
+    JsonValue& operator=(const JsonValue&) = default;
     
-    JsonValue(Type t)               : _t(t), _copy_ptr(nullptr)
-    {
-        switch (_t) {
-            case String: _string = new TString(); break;
-            case Object: _object = new TObject(); break;
-            case Array:  _array  = new TArray();  break;
-            default:
-                break;
-        }
-    }
+    JsonValue(JsonValue&&) noexcept = default;
+    JsonValue& operator=(JsonValue&&) noexcept = default;
     
-    explicit JsonValue(std::initializer_list<TObject::value_type> list) : _t(Object), _object(new TObject(list)) {}
-    explicit JsonValue(std::initializer_list<TArray::value_type> list)  : _t(Array),  _array(new TArray(list)) {}
+    explicit JsonValue(std::initializer_list<TObject::value_type> list) : _v(TObject(list)) {}
+    explicit JsonValue(std::initializer_list<TArray::value_type> list)  : _v(TArray(list)) {}
     
-    explicit JsonValue(bool v)      : _t(Boolean), _boolean(v) {}
-    explicit JsonValue(int64_t v)   : _t(Integer), _integer(v) {}
-    explicit JsonValue(double v)    : _t(Double),  _double(v) {}
-    explicit JsonValue(const char* v) : _t(String)
-    {
-        _string = new TString(v);
-    }
-    explicit JsonValue(const TString& v) : _t(String)
-    {
-        _string = new TString(v);
-    }
-    explicit JsonValue(const std::string_view& v) : _t(String)
-    {
-        _string = new TString(v);
-    }
-    explicit JsonValue(const TArray& v) : _t(Array)
-    {
-        _array = new TArray(v);
-    }
-    explicit JsonValue(const TObject& v) : _t(Object)
-    {
-        _object = new TObject(v);
-    }
-    
-    // Copy / Move
-    
-    JsonValue(const JsonValue & o)
-    {
-        copyFrom(o);
-    }
-    
-    JsonValue(JsonValue && o) : _t(o._t), _copy_ptr(o._copy_ptr)
-    {
-        o._t = NaT;
-    }
-    
-    JsonValue & operator=(const JsonValue & o)
-    {
-        if (&o != this) {
-            destroy();
-            copyFrom(o);
-        }
-        return *this;
-    }
-    
-    JsonValue & operator=(JsonValue && o)
-    {
-        _t = o._t;
-        _copy_ptr = o._copy_ptr;
-        o._t = NaT;
-        return *this;
-    }
-    
-    // Destructor
-    
-    ~JsonValue()
-    {
-        destroy();
-    }
+    explicit JsonValue(bool v)              : _v(v) {}
+    explicit JsonValue(int64_t v)           : _v(v) {}
+    explicit JsonValue(double v)            : _v(v) {}
+    explicit JsonValue(const char* v)       : _v(v) {}
+    explicit JsonValue(const TString& v)    : _v(v) {}
+    explicit JsonValue(const std::string_view& v) : _v(TString(v)) {}
+    explicit JsonValue(const TArray& v)     : _v(v) {}
+    explicit JsonValue(const TObject& v)    : _v(v) {}
     
     // operators
     
-    bool operator==(const JsonValue& other) const;
+    bool operator==(const JsonValue& other) const
+    {
+        return _v == other._v;
+    }
+    
     bool operator!=(const JsonValue& other) const
     {
-        return !this->operator==(other);
+        return _v != other._v;
     }
     
     // Object access
@@ -142,50 +92,37 @@ public:
     
     void assign(bool value)
     {
-        destroy();
-        _t = Boolean;
-        _boolean = value;
+        _v = value;
     }
     
     void assign(int64_t value)
     {
-        destroy();
-        _t = Integer;
-        _integer = value;
+        _v = value;
     }
     
     void assign(double value)
     {
-        destroy();
-        _t = Double;
-        _double = value;
+        _v = value;
     }
     
     void assign(const TString & value)
     {
-        destroy();
-        _t = String;
-        _string = new TString(value);
+        _v = value;
     }
     
     void assign(const TObject & value)
     {
-        destroy();
-        _t = Object;
-        _object = new TObject(value);
+        _v = value;
     }
     
     void assign(const TArray & value)
     {
-        destroy();
-        _t = Array;
-        _array = new TArray(value);
+        _v = value;
     }
     
     void assignNull()
     {
-        destroy();
-        _t = Null;
+        _v = TNull::Value;
     }
     
     // Append / Insert
@@ -200,65 +137,65 @@ public:
     
     Type type() const
     {
-        return _t;
+        return static_cast<Type>(_v.index());
     }
     
     const TObject & asObject() const
     {
-        castToPtrType(Object);
-        return *_object;
+        castToType(Object);
+        return std::get<TObject>(_v);
     }
     
     TObject & asMutableObject()
     {
-        castToPtrType(Object);
-        return *_object;
+        castToType(Object);
+        return std::get<TObject>(_v);
     }
     
     const TArray & asArray() const
     {
-        castToPtrType(Array);
-        return *_array;
+        castToType(Array);
+        return std::get<TArray>(_v);
     }
     
     TArray & asMutableArray()
     {
-        castToPtrType(Array);
-        return *_array;
+        castToType(Array);
+        return std::get<TArray>(_v);
     }
     
     const TString & asString() const
     {
-        castToPtrType(String);
-        return *_string;
+        castToType(String);
+        return std::get<TString>(_v);
     }
     
     TString & asMutableString()
     {
-        castToPtrType(String);
-        return *_string;
+        castToType(String);
+        return std::get<TString>(_v);
     }
     
     double asDouble() const
     {
-        if (_t == Integer) {
+        if (type() == Integer) {
             // Auto-cast from integer to double
-            return static_cast<double>(_integer);
+            return std::get<int64_t>(_v);
         }
         castToType(Double);
-        return _double;
+        return std::get<double>(_v);
     }
     
     int64_t asInteger() const
     {
         castToType(Integer);
-        return _integer;
+        return std::get<int64_t>(_v);
     }
     
     bool asBoolean() const
     {
         castToType(Boolean);
-        return _boolean;
+        return std::get<bool>(_v);
     }
     
     ByteArray asBase64() const;
@@ -267,17 +204,17 @@ public:
         
     bool isNull() const noexcept
     {
-        return _t == Null;
+        return type() == Null;
     }
     
     bool isValid() const noexcept
     {
-        return _t != NaT;
+        return type() != NaT;
     }
     
     bool isType(Type t) const noexcept
     {
-        return _t == t;
+        return type() == t;
     }
     
     bool containsValueAtPath(const std::string & path, Type expected_type = NaT) const
@@ -363,71 +300,37 @@ public:
     
 private:
     
-    // Private members
+    enum class TNaT  { Value };
+    enum class TNull { Value };
+
+    // Be aware that order of the types in variant must match order
+    // in enum Type. If not, then type() function will not work properly.
     
-    Type _t;
-    union
-    {
-        bool        _boolean;
-        int64_t     _integer;
-        double      _double;
-        TObject *   _object;
-        TArray *    _array;
-        TString *   _string;
-        void *      _copy_ptr;
-    };
+    typedef std::variant
+    <
+        TNaT,
+        TNull,
+        TObject,
+        TArray,
+        TString,
+        int64_t,
+        double,
+        bool
+    > Value;
+
+    Value _v;
     
     // Private methods
     
     const JsonValue * lookForValueAtPath(const std::string & path, Type expected_type, bool required) const;
-    
-    void destroy()
-    {
-        switch (_t) {
-            case Object:
-                delete _object;
-                break;
-            case Array:
-                delete _array;
-                break;
-            case String:
-                detail::StringCleanup(*_string);
-                delete _string;
-                break;
-            default:
-                break;
-        }
-        _integer = 0;
-    }
-    
-    void copyFrom(const JsonValue & o)
-    {
-        _t = o._t;
-        switch (o._t) {
-            case String: _string = new TString(*o._string); break;
-            case Object: _object = new TObject(*o._object); break;
-            case Array:  _array  = new TArray(*o._array);   break;
-            default:
-                _copy_ptr = o._copy_ptr;
-                break;
-        }
-    }
-    
+        
     void castToType(Type t) const
     {
-        if (_t != t) {
+        if (type() != t) {
             throw std::logic_error("Unable to cast JsonValue to " + typeToName(t));
         }
     }
-    
-    void castToPtrType(Type t) const
-    {
-        castToType(t);
-        if (_object == nullptr) {
-            throw std::logic_error("JsonValue with type " + typeToName(t) + " has no ");
-        }
-    }
-    
+        
     static std::string typeToName(Type t);
 };
 

--- a/include/cc7/json/JsonValue.h
+++ b/include/cc7/json/JsonValue.h
@@ -48,17 +48,17 @@ public:
     JsonValue() noexcept                             : _v(TNaT::Value) {}
     JsonValue(Type t) noexcept;
         
-    explicit JsonValue(std::initializer_list<TObject::value_type> list) : _v(TObject(list)) {}
-    explicit JsonValue(std::initializer_list<TArray::value_type> list)  : _v(TArray(list)) {}
+    explicit JsonValue(std::initializer_list<TObject::value_type> list) noexcept : _v(TObject(list)) {}
+    explicit JsonValue(std::initializer_list<TArray::value_type> list) noexcept : _v(TArray(list)) {}
     
     explicit JsonValue(bool v) noexcept              : _v(v) {}
     explicit JsonValue(int64_t v) noexcept           : _v(v) {}
     explicit JsonValue(double v) noexcept            : _v(v) {}
-    explicit JsonValue(const TString& v)             : _v(v) {}
-    explicit JsonValue(const std::string_view& v)    : _v(TString(v)) {}
-    explicit JsonValue(const char* v)                : _v(TString(v)) {}
-    explicit JsonValue(const TArray& v)              : _v(v) {}
-    explicit JsonValue(const TObject& v)             : _v(v) {}
+    explicit JsonValue(const TString& v) noexcept    : _v(v) {}
+    explicit JsonValue(const std::string_view& v) noexcept : _v(TString(v)) {}
+    explicit JsonValue(const char* v) noexcept             : _v(TString(v)) {}
+    explicit JsonValue(const TArray& v) noexcept     : _v(v) {}
+    explicit JsonValue(const TObject& v) noexcept    : _v(v) {}
     
     // Destructor
     ~JsonValue();
@@ -111,19 +111,19 @@ public:
         _v = value;
     }
     
-    void assign(const TString & value)
+    void assign(const TString & value) noexcept
     {
         secureCleanup();
         _v = value;
     }
     
-    void assign(const TObject & value)
+    void assign(const TObject & value) noexcept
     {
         secureCleanup();
         _v = value;
     }
     
-    void assign(const TArray & value)
+    void assign(const TArray & value) noexcept
     {
         secureCleanup();
         _v = value;
@@ -138,8 +138,8 @@ public:
     // Append / Insert
     
     void reserve(size_t count);
-    void pushBack(const JsonValue& value);
-    void pushBack(std::initializer_list<TArray::value_type> list);
+    void pushBack(const JsonValue& value) noexcept;
+    void pushBack(std::initializer_list<TArray::value_type> list) noexcept;
     void insert(const std::string& key, const JsonValue& value);
     void insert(std::initializer_list<TObject::value_type> list);
     
@@ -337,7 +337,7 @@ private:
         
     void castToType(Type t) const;
         
-    static const char * typeToName(Type t) noexcept;
+    static std::string typeToName(Type t) noexcept;
 };
 
 } // namespace cc7::json

--- a/include/cc7/json/JsonValue.h
+++ b/include/cc7/json/JsonValue.h
@@ -45,36 +45,39 @@ public:
     typedef std::vector<JsonValue> TArray;
     typedef std::string TString;
         
-    JsonValue()                             : _v(TNaT::Value) {}
-    JsonValue(Type t);
+    JsonValue() noexcept                             : _v(TNaT::Value) {}
+    JsonValue(Type t) noexcept;
+        
+    explicit JsonValue(std::initializer_list<TObject::value_type> list) noexcept : _v(TObject(list)) {}
+    explicit JsonValue(std::initializer_list<TArray::value_type> list) noexcept : _v(TArray(list)) {}
+    
+    explicit JsonValue(bool v) noexcept              : _v(v) {}
+    explicit JsonValue(int64_t v) noexcept           : _v(v) {}
+    explicit JsonValue(double v) noexcept            : _v(v) {}
+    explicit JsonValue(const TString& v) noexcept    : _v(v) {}
+    explicit JsonValue(const std::string_view& v) noexcept : _v(TString(v)) {}
+    explicit JsonValue(const char* v) noexcept             : _v(TString(v)) {}
+    explicit JsonValue(const TArray& v) noexcept     : _v(v) {}
+    explicit JsonValue(const TObject& v) noexcept    : _v(v) {}
+    
+    // Destructor
     ~JsonValue();
     
+    // Copy
     JsonValue(const JsonValue&) = default;
-    JsonValue& operator=(const JsonValue&) = default;
-    
+    JsonValue& operator=(const JsonValue&);
+    // Move
     JsonValue(JsonValue&&) noexcept = default;
-    JsonValue& operator=(JsonValue&&) noexcept = default;
-    
-    explicit JsonValue(std::initializer_list<TObject::value_type> list) : _v(TObject(list)) {}
-    explicit JsonValue(std::initializer_list<TArray::value_type> list)  : _v(TArray(list)) {}
-    
-    explicit JsonValue(bool v)              : _v(v) {}
-    explicit JsonValue(int64_t v)           : _v(v) {}
-    explicit JsonValue(double v)            : _v(v) {}
-    explicit JsonValue(const char* v)       : _v(v) {}
-    explicit JsonValue(const TString& v)    : _v(v) {}
-    explicit JsonValue(const std::string_view& v) : _v(TString(v)) {}
-    explicit JsonValue(const TArray& v)     : _v(v) {}
-    explicit JsonValue(const TObject& v)    : _v(v) {}
-    
+    JsonValue& operator=(JsonValue&&) noexcept;
+
     // operators
     
-    bool operator==(const JsonValue& other) const
+    bool operator==(const JsonValue& other) const noexcept
     {
         return _v == other._v;
     }
     
-    bool operator!=(const JsonValue& other) const
+    bool operator!=(const JsonValue& other) const noexcept
     {
         return _v != other._v;
     }
@@ -90,46 +93,53 @@ public:
     
     // assign
     
-    void assign(bool value)
+    void assign(bool value) noexcept
     {
+        secureCleanup();
         _v = value;
     }
     
-    void assign(int64_t value)
+    void assign(int64_t value) noexcept
     {
+        secureCleanup();
         _v = value;
     }
     
-    void assign(double value)
+    void assign(double value) noexcept
     {
+        secureCleanup();
         _v = value;
     }
     
-    void assign(const TString & value)
+    void assign(const TString & value) noexcept
     {
+        secureCleanup();
         _v = value;
     }
     
-    void assign(const TObject & value)
+    void assign(const TObject & value) noexcept
     {
+        secureCleanup();
         _v = value;
     }
     
-    void assign(const TArray & value)
+    void assign(const TArray & value) noexcept
     {
+        secureCleanup();
         _v = value;
     }
     
-    void assignNull()
+    void assignNull() noexcept
     {
+        secureCleanup();
         _v = TNull::Value;
     }
     
     // Append / Insert
     
     void reserve(size_t count);
-    void pushBack(const JsonValue& value);
-    void pushBack(std::initializer_list<TArray::value_type> list);
+    void pushBack(const JsonValue& value) noexcept;
+    void pushBack(std::initializer_list<TArray::value_type> list) noexcept;
     void insert(const std::string& key, const JsonValue& value);
     void insert(std::initializer_list<TObject::value_type> list);
     
@@ -268,30 +278,32 @@ public:
     cc7::ByteArray dataFromBase64UrlStringAtPath(const std::string & path) const;
     cc7::ByteArray dataFromHexStringAtPath(const std::string & path) const;
     
-    void assignBase64(const cc7::ByteRange & data);
-    void assignBase64Url(const cc7::ByteRange & data);
-    void assignHexString(const cc7::ByteRange & data);
+    void assignBase64(const cc7::ByteRange & data) noexcept;
+    void assignBase64Url(const cc7::ByteRange & data) noexcept;
+    void assignHexString(const cc7::ByteRange & data) noexcept;
     
     // Static constructs
 
-    static JsonValue null();
-    static JsonValue yes();
-    static JsonValue no();
-    static JsonValue object();
-    static JsonValue array();
-    static JsonValue string();
-    static JsonValue object(std::initializer_list<TObject::value_type> list);
-    static JsonValue array(std::initializer_list<TArray::value_type> list);
-    static JsonValue string(const std::string_view& str);
+    static JsonValue null() noexcept;
+    static JsonValue yes() noexcept;
+    static JsonValue no() noexcept;
+    static JsonValue array() noexcept;
+    static JsonValue array(std::initializer_list<TArray::value_type> list) noexcept;
+    static JsonValue object() noexcept;
+    static JsonValue object(std::initializer_list<TObject::value_type> list) noexcept;
+    static JsonValue string() noexcept;
+    static JsonValue string(const TString& str) noexcept;
+    static JsonValue string(const std::string_view& str) noexcept;
+    static JsonValue string(const char* str) noexcept;
     
-    static JsonValue boolean(bool value);
-    static JsonValue count(size_t c);
-    static JsonValue integer(int64_t value);
-    static JsonValue number(double value);
+    static JsonValue boolean(bool value) noexcept;
+    static JsonValue count(size_t c) noexcept;
+    static JsonValue integer(int64_t value) noexcept;
+    static JsonValue number(double value) noexcept;
 
-    static JsonValue base64(const ByteRange& data);
-    static JsonValue base64Url(const ByteRange& data);
-    static JsonValue hexString(const ByteRange& data);
+    static JsonValue base64(const ByteRange& data) noexcept;
+    static JsonValue base64Url(const ByteRange& data) noexcept;
+    static JsonValue hexString(const ByteRange& data) noexcept;
     
     
     // Debug
@@ -322,16 +334,13 @@ private:
     
     // Private methods
     
+    void secureCleanup() noexcept;
+    
     const JsonValue * lookForValueAtPath(const std::string & path, Type expected_type, bool required) const;
         
-    void castToType(Type t) const
-    {
-        if (type() != t) {
-            throw std::logic_error("Unable to cast JsonValue to " + typeToName(t));
-        }
-    }
+    void castToType(Type t) const;
         
-    static std::string typeToName(Type t);
+    static std::string typeToName(Type t) noexcept;
 };
 
 } // namespace cc7::json

--- a/include/cc7/json/JsonValue.h
+++ b/include/cc7/json/JsonValue.h
@@ -145,10 +145,7 @@ public:
     
     // casting
     
-    Type type() const
-    {
-        return static_cast<Type>(_v.index());
-    }
+    Type type() const noexcept;
     
     const TObject & asObject() const
     {

--- a/include/cc7/json/JsonValue.h
+++ b/include/cc7/json/JsonValue.h
@@ -48,17 +48,17 @@ public:
     JsonValue() noexcept                             : _v(TNaT::Value) {}
     JsonValue(Type t) noexcept;
         
-    explicit JsonValue(std::initializer_list<TObject::value_type> list) noexcept : _v(TObject(list)) {}
-    explicit JsonValue(std::initializer_list<TArray::value_type> list) noexcept : _v(TArray(list)) {}
+    explicit JsonValue(std::initializer_list<TObject::value_type> list) : _v(TObject(list)) {}
+    explicit JsonValue(std::initializer_list<TArray::value_type> list)  : _v(TArray(list)) {}
     
     explicit JsonValue(bool v) noexcept              : _v(v) {}
     explicit JsonValue(int64_t v) noexcept           : _v(v) {}
     explicit JsonValue(double v) noexcept            : _v(v) {}
-    explicit JsonValue(const TString& v) noexcept    : _v(v) {}
-    explicit JsonValue(const std::string_view& v) noexcept : _v(TString(v)) {}
-    explicit JsonValue(const char* v) noexcept             : _v(TString(v)) {}
-    explicit JsonValue(const TArray& v) noexcept     : _v(v) {}
-    explicit JsonValue(const TObject& v) noexcept    : _v(v) {}
+    explicit JsonValue(const TString& v)             : _v(v) {}
+    explicit JsonValue(const std::string_view& v)    : _v(TString(v)) {}
+    explicit JsonValue(const char* v)                : _v(TString(v)) {}
+    explicit JsonValue(const TArray& v)              : _v(v) {}
+    explicit JsonValue(const TObject& v)             : _v(v) {}
     
     // Destructor
     ~JsonValue();
@@ -111,19 +111,19 @@ public:
         _v = value;
     }
     
-    void assign(const TString & value) noexcept
+    void assign(const TString & value)
     {
         secureCleanup();
         _v = value;
     }
     
-    void assign(const TObject & value) noexcept
+    void assign(const TObject & value)
     {
         secureCleanup();
         _v = value;
     }
     
-    void assign(const TArray & value) noexcept
+    void assign(const TArray & value)
     {
         secureCleanup();
         _v = value;
@@ -138,8 +138,8 @@ public:
     // Append / Insert
     
     void reserve(size_t count);
-    void pushBack(const JsonValue& value) noexcept;
-    void pushBack(std::initializer_list<TArray::value_type> list) noexcept;
+    void pushBack(const JsonValue& value);
+    void pushBack(std::initializer_list<TArray::value_type> list);
     void insert(const std::string& key, const JsonValue& value);
     void insert(std::initializer_list<TObject::value_type> list);
     
@@ -337,7 +337,7 @@ private:
         
     void castToType(Type t) const;
         
-    static std::string typeToName(Type t) noexcept;
+    static const char * typeToName(Type t) noexcept;
 };
 
 } // namespace cc7::json

--- a/src/cc7/json/JsonReader.cpp
+++ b/src/cc7/json/JsonReader.cpp
@@ -16,6 +16,7 @@
 
 #include <cc7/json/JsonReader.h>
 #include <cc7/json/JsonException.h>
+#include <cc7/detail/StringUtils.h>
 
 namespace cc7::json {
 

--- a/src/cc7/json/JsonValue.cpp
+++ b/src/cc7/json/JsonValue.cpp
@@ -60,6 +60,15 @@ JsonValue::~JsonValue()
     secureCleanup();
 }
 
+JsonValue::Type JsonValue::type() const noexcept
+{
+    auto index = _v.index();
+    if (index != std::variant_npos) {
+        return static_cast<Type>(index);
+    }
+    return NaT;
+}
+
 // Object access
 
 JsonValue& JsonValue::operator[](const std::string& key)

--- a/src/cc7/json/JsonValue.cpp
+++ b/src/cc7/json/JsonValue.cpp
@@ -21,32 +21,28 @@
 
 namespace cc7::json {
 
-// Operators
+// Constructor
 
-bool JsonValue::operator==(const JsonValue& other) const
+JsonValue::JsonValue(Type t)
 {
-    if (other.isType(_t)) {
-        switch (_t) {
-            case Array:
-                return *_array == *other._array;
-            case String:
-                return *_string == *other._string;
-            case Object:
-                return *_object == *other._object;
-            case Boolean:
-                return _boolean == other._boolean;
-            case Integer:
-                return _integer == other._integer;
-            case Double:
-                return _double == other._double;
-            case NaT:
-            case Null:
-                return true;
-            default:
-                break;
-        }
+    switch (t) {
+        case NaT:       _v = TNaT::Value; break;
+        case Null:      _v = TNull::Value; break;
+        case String:    _v = TString(); break;
+        case Object:    _v = TObject(); break;
+        case Array:     _v = TArray(); break;
+        case Integer:   _v = 0; break;
+        case Double:    _v = 0.0; break;
+        case Boolean:   _v = false; break;
     }
-    return false;
+}
+
+JsonValue::~JsonValue()
+{
+    if (type() == String) {
+        // Cleanup string in destructor
+        detail::StringCleanup(std::get<TString>(_v));
+    }
 }
 
 // Object access
@@ -164,30 +160,32 @@ ByteArray JsonValue::dataFromHexStringAtPath(const std::string & path) const
 
 ByteArray JsonValue::asBase64() const
 {
-    castToType(String);
-    return Base64::decode(*_string);
+    return Base64::decode(asString());
 }
 
 ByteArray JsonValue::asBase64Url() const
 {
-    castToType(String);
-    return Base64::urlDecode(*_string);
+    return Base64::urlDecode(asString());
 }
 
 ByteArray JsonValue::asHexString() const
 {
-    castToType(String);
-    return FromHexString(*_string);
+    return FromHexString(asString());
 }
 
 // Append / Insert
 
 void JsonValue::reserve(size_t count)
 {
-    switch (_t) {
-        case Array: _array->reserve(count); break;
-        case String: _string->reserve(count); break;
-        default: break;
+    switch (type()) {
+        case Array:
+            asMutableArray().reserve(count);
+            break;
+        case String:
+            asMutableString().reserve(count);
+            break;
+        default:
+            break;
     }
 }
 

--- a/src/cc7/json/JsonValue.cpp
+++ b/src/cc7/json/JsonValue.cpp
@@ -213,12 +213,12 @@ void JsonValue::reserve(size_t count)
     }
 }
 
-void JsonValue::pushBack(const JsonValue &value)
+void JsonValue::pushBack(const JsonValue &value) noexcept
 {
     asMutableArray().push_back(value);
 }
 
-void JsonValue::pushBack(std::initializer_list<TArray::value_type> list)
+void JsonValue::pushBack(std::initializer_list<TArray::value_type> list) noexcept
 {
     auto& array = asMutableArray();
     array.insert(array.end(), list);
@@ -247,11 +247,11 @@ void JsonValue::secureCleanup() noexcept
 void JsonValue::castToType(Type t) const
 {
     if (type() != t) {
-        throw std::logic_error("Unable to cast JsonValue to " + std::string(typeToName(t)));
+        throw std::logic_error("Unable to cast JsonValue to " + typeToName(t));
     }
 }
 
-const char * JsonValue::typeToName(Type t) noexcept
+std::string JsonValue::typeToName(Type t) noexcept
 {
     switch (t) {
         case Null: return "Null";

--- a/src/cc7/json/JsonValue.cpp
+++ b/src/cc7/json/JsonValue.cpp
@@ -21,9 +21,9 @@
 
 namespace cc7::json {
 
-// Constructor
+// Constructor, Destructor, Copy, Move
 
-JsonValue::JsonValue(Type t)
+JsonValue::JsonValue(Type t) noexcept
 {
     switch (t) {
         case NaT:       _v = TNaT::Value; break;
@@ -37,12 +37,27 @@ JsonValue::JsonValue(Type t)
     }
 }
 
+JsonValue& JsonValue::operator=(const JsonValue& other)
+{
+    if (this != &other) {
+        secureCleanup();
+        _v = other._v;
+    }
+    return *this;
+}
+
+JsonValue& JsonValue::operator=(JsonValue&& other) noexcept
+{
+    if (this != &other) {
+        secureCleanup();
+        _v = std::move(other._v);
+    }
+    return *this;
+}
+
 JsonValue::~JsonValue()
 {
-    if (type() == String) {
-        // Cleanup string in destructor
-        detail::StringCleanup(std::get<TString>(_v));
-    }
+    secureCleanup();
 }
 
 // Object access
@@ -124,17 +139,17 @@ const JsonValue * JsonValue::lookForValueAtPath(const std::string & path, Type e
 
 // ByteRange binding
 
-void JsonValue::assignBase64(const ByteRange &data)
+void JsonValue::assignBase64(const ByteRange &data) noexcept
 {
     assign(data.base64());
 }
 
-void JsonValue::assignBase64Url(const ByteRange &data)
+void JsonValue::assignBase64Url(const ByteRange &data) noexcept
 {
     assign(data.base64Url());
 }
 
-void JsonValue::assignHexString(const ByteRange &data)
+void JsonValue::assignHexString(const ByteRange &data) noexcept
 {
     assign(data.hexadecimal());
 }
@@ -189,12 +204,12 @@ void JsonValue::reserve(size_t count)
     }
 }
 
-void JsonValue::pushBack(const JsonValue &value)
+void JsonValue::pushBack(const JsonValue &value) noexcept
 {
     asMutableArray().push_back(value);
 }
 
-void JsonValue::pushBack(std::initializer_list<TArray::value_type> list)
+void JsonValue::pushBack(std::initializer_list<TArray::value_type> list) noexcept
 {
     auto& array = asMutableArray();
     array.insert(array.end(), list);
@@ -212,7 +227,22 @@ void JsonValue::insert(std::initializer_list<TObject::value_type> list)
 
 // Utility
 
-std::string JsonValue::typeToName(Type t)
+void JsonValue::secureCleanup() noexcept
+{
+    if (type() == String) {
+        // Cleanup string in destructor or in value assignment.
+        detail::StringCleanup(std::get<TString>(_v));
+    }
+}
+
+void JsonValue::castToType(Type t) const
+{
+    if (type() != t) {
+        throw std::logic_error("Unable to cast JsonValue to " + typeToName(t));
+    }
+}
+
+std::string JsonValue::typeToName(Type t) noexcept
 {
     switch (t) {
         case Null: return "Null";
@@ -228,82 +258,92 @@ std::string JsonValue::typeToName(Type t)
 
 // Static constructors
 
-JsonValue JsonValue::object()
+JsonValue JsonValue::object() noexcept
 {
     return JsonValue(Object);
 }
 
-JsonValue JsonValue::array()
+JsonValue JsonValue::array() noexcept
 {
     return JsonValue(Array);
 }
 
-JsonValue JsonValue::string()
+JsonValue JsonValue::string() noexcept
 {
     return JsonValue(String);
 }
 
-JsonValue JsonValue::object(std::initializer_list<TObject::value_type> list)
+JsonValue JsonValue::object(std::initializer_list<TObject::value_type> list) noexcept
 {
     return JsonValue(list);
 }
 
-JsonValue JsonValue::array(std::initializer_list<TArray::value_type> list)
+JsonValue JsonValue::array(std::initializer_list<TArray::value_type> list) noexcept
 {
     return JsonValue(list);
 }
 
-JsonValue JsonValue::string(const std::string_view& str)
+JsonValue JsonValue::string(const std::string_view& str) noexcept
 {
     return JsonValue(str);
 }
 
-JsonValue JsonValue::null()
+JsonValue JsonValue::string(const char* str) noexcept
+{
+    return JsonValue(str);
+}
+
+JsonValue JsonValue::string(const TString& str) noexcept
+{
+    return JsonValue(str);
+}
+
+JsonValue JsonValue::null() noexcept
 {
     return JsonValue(Null);
 }
 
-JsonValue JsonValue::yes()
+JsonValue JsonValue::yes() noexcept
 {
     return JsonValue(true);
 }
 
-JsonValue JsonValue::no()
+JsonValue JsonValue::no() noexcept
 {
     return JsonValue(false);
 }
 
-JsonValue JsonValue::boolean(bool value)
+JsonValue JsonValue::boolean(bool value) noexcept
 {
     return JsonValue(value);
 }
 
-JsonValue JsonValue::count(size_t c)
+JsonValue JsonValue::count(size_t c) noexcept
 {
     return JsonValue((int64_t)c);
 }
 
-JsonValue JsonValue::integer(int64_t value)
+JsonValue JsonValue::integer(int64_t value) noexcept
 {
     return JsonValue(value);
 }
 
-JsonValue JsonValue::number(double value)
+JsonValue JsonValue::number(double value) noexcept
 {
     return JsonValue(value);
 }
 
-JsonValue JsonValue::base64(const ByteRange& data)
+JsonValue JsonValue::base64(const ByteRange& data) noexcept
 {
     return JsonValue(data.base64());
 }
 
-JsonValue JsonValue::base64Url(const ByteRange& data)
+JsonValue JsonValue::base64Url(const ByteRange& data) noexcept
 {
     return JsonValue(data.base64Url());
 }
 
-JsonValue JsonValue::hexString(const ByteRange& data)
+JsonValue JsonValue::hexString(const ByteRange& data) noexcept
 {
     return JsonValue(data.hexadecimal());
 }

--- a/src/cc7/json/JsonValue.cpp
+++ b/src/cc7/json/JsonValue.cpp
@@ -213,12 +213,12 @@ void JsonValue::reserve(size_t count)
     }
 }
 
-void JsonValue::pushBack(const JsonValue &value) noexcept
+void JsonValue::pushBack(const JsonValue &value)
 {
     asMutableArray().push_back(value);
 }
 
-void JsonValue::pushBack(std::initializer_list<TArray::value_type> list) noexcept
+void JsonValue::pushBack(std::initializer_list<TArray::value_type> list)
 {
     auto& array = asMutableArray();
     array.insert(array.end(), list);
@@ -247,11 +247,11 @@ void JsonValue::secureCleanup() noexcept
 void JsonValue::castToType(Type t) const
 {
     if (type() != t) {
-        throw std::logic_error("Unable to cast JsonValue to " + typeToName(t));
+        throw std::logic_error("Unable to cast JsonValue to " + std::string(typeToName(t)));
     }
 }
 
-std::string JsonValue::typeToName(Type t) noexcept
+const char * JsonValue::typeToName(Type t) noexcept
 {
     switch (t) {
         case Null: return "Null";

--- a/src/cc7tests/tests/cc7json/JsonValueTests.cpp
+++ b/src/cc7tests/tests/cc7json/JsonValueTests.cpp
@@ -172,10 +172,21 @@ public:
     
     void testMove()
     {
+        // JsonValue move has a slightly different behavior now, because
+        // internal `std::variant` keeps the type of value as is. So, it's
+        // no longer defaulted to NaT as we did in original implementation.
+        //
+        // The analyzer may report a warning "Method called on moved-from object",
+        // but that's the point of this test.
+        
         auto val1 = JsonValue({ JsonValue("Hello"), JsonValue("World")});
         auto val2 = std::move(val1);
-        ccstAssertTrue(val1.isType(JsonValue::NaT));
+        
+        ccstAssertTrue(val1.isType(JsonValue::Array));
         ccstAssertTrue(val2.isType(JsonValue::Array));
+        ccstAssertEqual(0, val1.asArray().size());  // array in source object should be zeroed
+        ccstAssertEqual(2, val2.asArray().size());
+        
         ccstAssertEqual(val2, JsonValue({ JsonValue("Hello"), JsonValue("World")}));
     }
     


### PR DESCRIPTION
This PR contains new JsonValue implementation based on std::variant<>. This avoids false positives reported in static analysis that JsonValue causes potential memory leaks.